### PR TITLE
Bug fix in batch norm call

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ def model_emb_cnn(num_classes, raw_dim, n_subclusters, use_bias=False):
     # second block
     xr = tf.keras.layers.ReLU()(x)
     xr = tf.keras.layers.Conv2D(16, 3, activation='linear', padding='same', kernel_regularizer=l2_weight_decay, use_bias=use_bias)(xr)
-    x = tf.keras.layers.BatchNormalization()(x)
+    xr = tf.keras.layers.BatchNormalization()(xr)
     xr = tf.keras.layers.ReLU()(xr)
     xr = tf.keras.layers.Conv2D(16, 3, activation='linear', padding='same', kernel_regularizer=l2_weight_decay, use_bias=use_bias)(xr)
     x = tf.keras.layers.Add()([x, xr])


### PR DESCRIPTION
Replacing variable from x to xr in batch norm call to be consistent with subsequent blocks, ResNet format and DCASE 2022 network.